### PR TITLE
strip summoner name since Riot does this too in their displays

### DIFF
--- a/riot_transmute/match_to_game.py
+++ b/riot_transmute/match_to_game.py
@@ -234,7 +234,7 @@ def match_to_game(match_dto: dict, add_names: bool = False) -> game_dto.LolGame:
             )
 
             if participant_identity:
-                player["inGameName"] = participant_identity["summonerName"]
+                player["inGameName"] = participant_identity["summonerName"].strip()
                 player["profileIconId"] = participant_identity["profileIcon"]
 
             # roleml compatibility


### PR DESCRIPTION
An example game is: https://matchhistory.na.leagueoflegends.com/en/#match-details/ESPORTSTMNT01/1434268?gameHash=6a9d4306ee294f85&tab=overview

MK Terco, red team top laner, has a leading space in his summoner name, which isn't shown in the MH linked above, so imo stripping spaces is part of the "canonical" summoner names used. If you'd rather not do this np just close this