### PR TITLE
Ignore Kayn transforms for now

### DIFF
--- a/riot_transmute/v5/match_timeline_to_game.py
+++ b/riot_transmute/v5/match_timeline_to_game.py
@@ -316,6 +316,9 @@ def match_timeline_to_game(
                 )
                 continue
 
+            elif event["type"] == "CHAMPION_TRANSFORM":
+                pass
+
             # Events not handled, we raise
             else:
                 raise ValueError(event)


### PR DESCRIPTION
This is a temporary workaround that will stop the library from crashing upon encountering transforms in V5 jsons with Kayn in them by just ignoring them altogether